### PR TITLE
Remove global configuration

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,8 @@
+continue
+backtrace
+stack
+trace
+c
+continue
+c
+target_table_name

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.2
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
 addons:
   postgresql: "9.3"
   code_climate:
     repo_token: fcd6d8c28da900609a2cf903716d858621b8ce68152edbcebe6908a9a3f5d3d5
+before_install:
+  - gem update --system
+  - gem update bundler
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/README.md
+++ b/README.md
@@ -32,12 +32,34 @@ Make sure the tables you want to import contain columns named ```external_id``` 
 
 ### Configuration
 
-    BeetleETL.configure do |config|
-      config.transformation_file = # path to your transformation file
-      config.database_config = # sequel database config
-    # or config.database = # sequel database instance
-      config.external_source = ‘name_of_your_source’
-      config.logger = Logger.new(STDOUT)
+Create a configuration object
+
+    configuration = BeetleETL::Configuration.new do |config|
+      # path to your transformation file
+      config.transformation_file = "../my_fancy_transformations"
+
+      # sequel database config
+      config.database_config = {
+        adapter: 'postgres'
+        encoding: utf8
+        host: my_host
+        database: my_database
+        username: 'foo'
+        password: 'bar'
+        pool: 5
+        pool_timeout: 360
+        connect_timeout: 360
+      }
+      # or config.database = # sequel database instance
+
+      # name of your soruce
+      config.external_source = "important_data"
+
+      # target schema in case you use postgres schemas
+      config.target_schema = "public" # default
+
+      # logger
+      config.logger = Logger.new(STDOUT) # default
     end
 
 ### Defining Imports
@@ -66,8 +88,8 @@ Fill a ```transformation``` file with import directives like this:
           ON data.org_id = o.id
       SQL
     end
-    
-    
+
+
 ```import``` takes the name of the table you want to fill and the configuration as arguments.
 With ```columns``` you define what columns BeetleETL is supposed to fill in your application’s table.
 The ```query``` transforms the data. Make sure that you insert into ```#{stage_table}``` as the name of the actual table, that this inserts into will be filled in by BeetleETL during runtime.
@@ -76,7 +98,7 @@ Define any foreign references your table has to other tables using the ```refrec
 
 ### Running BeetleETL
 
-    BeetleETL.import
+    BeetleETL.import(configuration)
 
 ## Development
 

--- a/beetle_etl.gemspec
+++ b/beetle_etl.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sequel', '>= 4.0.0'
   spec.add_runtime_dependency 'activesupport', '>= 4.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'timecop', '>= 0.7.0'
   spec.add_development_dependency 'pg', '>= 0.18.0'

--- a/lib/beetle_etl/configuration.rb
+++ b/lib/beetle_etl/configuration.rb
@@ -1,0 +1,39 @@
+module BeetleETL
+  InvalidConfigurationError = Class.new(StandardError)
+
+  class Configuration
+    attr_accessor \
+      :transformation_file,
+      :stage_schema,
+      :external_source,
+      :logger
+
+    attr_writer \
+      :database,
+      :database_config,
+      :target_schema
+
+    def initialize
+      @target_schema = 'public'
+      @logger = ::Logger.new(STDOUT)
+    end
+
+    def database
+      if [@database, @database_config].none?
+        msg = "Either Sequel connection database_config or a Sequel Database object required"
+        raise InvalidConfigurationError.new(msg)
+      end
+
+      @database ||= Sequel.connect(@database_config)
+    end
+
+    def disconnect_database
+      database.disconnect if @database_config
+    end
+
+    def target_schema
+      @target_schema != 'public' ? @target_schema : nil
+    end
+
+  end
+end

--- a/lib/beetle_etl/dsl/dsl.rb
+++ b/lib/beetle_etl/dsl/dsl.rb
@@ -3,7 +3,8 @@ module BeetleETL
 
     attr_reader :column_names, :relations, :query_strings
 
-    def initialize(table_name)
+    def initialize(config, table_name)
+      @config = config
       @table_name = table_name
       @column_names = []
       @relations = {}
@@ -25,7 +26,10 @@ module BeetleETL
     # query helper methods
 
     def stage_table(table_name = nil)
-      BeetleETL::Naming.stage_table_name_sql(table_name || @table_name)
+      BeetleETL::Naming.stage_table_name_sql(
+        @config.external_source,
+        table_name || @table_name
+      )
     end
 
     def combined_key(*args)

--- a/lib/beetle_etl/dsl/transformation.rb
+++ b/lib/beetle_etl/dsl/transformation.rb
@@ -5,9 +5,9 @@ module BeetleETL
 
     attr_reader :table_name
 
-    def initialize(table_name, setup, helpers = nil)
+    def initialize(config, table_name, setup, helpers = nil)
       @table_name = table_name
-      @parsed = DSL.new(table_name).tap do |dsl|
+      @parsed = DSL.new(config, table_name).tap do |dsl|
         dsl.instance_exec(&helpers) if helpers
         dsl.instance_exec(&setup)
       end

--- a/lib/beetle_etl/dsl/transformation_loader.rb
+++ b/lib/beetle_etl/dsl/transformation_loader.rb
@@ -1,18 +1,19 @@
 module BeetleETL
   class TransformationLoader
 
-    def initialize
+    def initialize(config)
+      @config = config
       @transformations = []
       @helper_definitions = nil
     end
 
     def load
-      File.open(BeetleETL.config.transformation_file, 'r') do |file|
+      File.open(@config.transformation_file, 'r') do |file|
         instance_eval file.read
       end
 
       @transformations.map do |(table_name, setup)|
-        Transformation.new(table_name, setup, @helper_definitions)
+        Transformation.new(@config, table_name, setup, @helper_definitions)
       end
     end
 

--- a/lib/beetle_etl/import.rb
+++ b/lib/beetle_etl/import.rb
@@ -3,6 +3,10 @@ require 'active_support/core_ext/hash/deep_merge'
 module BeetleETL
   class Import
 
+    def initialize(config)
+      @config = config
+    end
+
     def run
       setup
       import
@@ -12,14 +16,14 @@ module BeetleETL
 
     def setup
       transformations.each do |t|
-        CreateStage.new(t.table_name, t.relations, t.column_names).run
+        CreateStage.new(@config, t.table_name, t.relations, t.column_names).run
       end
     end
 
     def import
-      data_report = AsyncStepRunner.new(data_steps).run
-      load_report = BeetleETL.database.transaction do
-        AsyncStepRunner.new(load_steps).run
+      data_report = AsyncStepRunner.new(@config, data_steps).run
+      load_report = @config.database.transaction do
+        AsyncStepRunner.new(@config, load_steps).run
       end
 
       data_report.deep_merge load_report
@@ -27,7 +31,7 @@ module BeetleETL
 
     def cleanup
       transformations.each do |t|
-        DropStage.new(t.table_name).run
+        DropStage.new(@config, t.table_name).run
       end
     end
 
@@ -36,22 +40,22 @@ module BeetleETL
     def data_steps
       transformations.flat_map do |t|
         [
-          Transform.new(t.table_name, t.dependencies, t.query),
-          MapRelations.new(t.table_name, t.relations),
-          TableDiff.new(t.table_name),
-          AssignIds.new(t.table_name),
+          Transform.new(@config, t.table_name, t.dependencies, t.query),
+          MapRelations.new(@config, t.table_name, t.relations),
+          TableDiff.new(@config, t.table_name),
+          AssignIds.new(@config, t.table_name),
         ]
       end
     end
 
     def load_steps
       transformations.map do |t|
-        Load.new(t.table_name, t.relations)
+        Load.new(@config, t.table_name, t.relations)
       end
     end
 
     def transformations
-      @transformations ||= TransformationLoader.new.load
+      @transformations ||= TransformationLoader.new(@config).load
     end
 
   end

--- a/lib/beetle_etl/naming.rb
+++ b/lib/beetle_etl/naming.rb
@@ -5,32 +5,22 @@ module BeetleETL
 
     extend self
 
-    def stage_table_name(table_name = nil)
-      name = (table_name || @table_name).to_s
-      digest = Digest::MD5.hexdigest(name)
-      "#{BeetleETL.config.external_source}-#{name}-#{digest}"[0, 63]
+    def stage_table_name(external_source, table_name)
+      digest = Digest::MD5.hexdigest(table_name.to_s)
+      "#{external_source.to_s}-#{table_name.to_s}-#{digest}"[0, 63]
     end
 
-    def stage_table_name_sql(table_name = nil)
-      %Q("#{stage_table_name(table_name)}")
+    def stage_table_name_sql(external_source, table_name)
+      %Q("#{stage_table_name(external_source, table_name)}")
     end
 
-    def target_table_name(table_name = nil)
-      name = (table_name || @table_name).to_s
-      [target_schema, name].compact.join('.')
+    def target_table_name(target_schema, table_name)
+      schema = target_schema ? target_schema.to_s : nil
+      [schema, table_name.to_s].compact.join('.')
     end
 
-    def target_table_name_sql(table_name = nil)
-      name = (table_name || @table_name).to_s
-      target_table_name= [target_schema, name].compact.join('"."')
-      %Q("#{target_table_name}")
-    end
-
-    private
-
-    def target_schema
-      target_schema = BeetleETL.config.target_schema
-      target_schema != 'public' ? target_schema : nil
+    def target_table_name_sql(target_schema, table_name)
+      %Q("#{target_table_name(target_schema, table_name)}")
     end
 
   end

--- a/lib/beetle_etl/reporter.rb
+++ b/lib/beetle_etl/reporter.rb
@@ -1,12 +1,13 @@
 module BeetleETL
   class Reporter
 
-    def initialize(report)
+    def initialize(config, report)
+      @config = config
       @report = report
     end
 
     def log_summary
-      BeetleETL.logger.info(summary)
+      @config.logger.info(summary)
     end
 
     private

--- a/lib/beetle_etl/steps/create_stage.rb
+++ b/lib/beetle_etl/steps/create_stage.rb
@@ -5,8 +5,8 @@ module BeetleETL
 
   class CreateStage < Step
 
-    def initialize(table_name, relations, column_names)
-      super(table_name)
+    def initialize(config, table_name, relations, column_names)
+      super(config, table_name)
       @relations = relations
       @column_names = column_names
     end

--- a/lib/beetle_etl/steps/load.rb
+++ b/lib/beetle_etl/steps/load.rb
@@ -6,8 +6,8 @@ module BeetleETL
       transition
     ]
 
-    def initialize(table_name, relations)
-      super(table_name)
+    def initialize(config, table_name, relations)
+      super(config, table_name)
       @relations = relations
     end
 

--- a/lib/beetle_etl/steps/map_relations.rb
+++ b/lib/beetle_etl/steps/map_relations.rb
@@ -1,8 +1,8 @@
 module BeetleETL
   class MapRelations < Step
 
-    def initialize(table_name, relations)
-      super(table_name)
+    def initialize(config, table_name, relations)
+      super(config, table_name)
       @relations = relations
     end
 

--- a/lib/beetle_etl/steps/step.rb
+++ b/lib/beetle_etl/steps/step.rb
@@ -2,10 +2,10 @@ module BeetleETL
 
   class Step
 
-    include BeetleETL::Naming
     attr_reader :table_name
 
-    def initialize(table_name)
+    def initialize(config, table_name)
+      @config = config
       @table_name = table_name
     end
 
@@ -22,11 +22,30 @@ module BeetleETL
     end
 
     def external_source
-      BeetleETL.config.external_source
+      @config.external_source
     end
 
     def database
-      BeetleETL.database
+      @config.database
+    end
+
+    # naming
+
+    def stage_table_name
+      BeetleETL::Naming.stage_table_name(@config.external_source, @table_name)
+    end
+
+    def stage_table_name_sql(table_name = nil)
+      table_name ||= @table_name
+      BeetleETL::Naming.stage_table_name_sql(@config.external_source, table_name)
+    end
+
+    def target_table_name
+      BeetleETL::Naming.target_table_name(@config.target_schema, @table_name)
+    end
+
+    def target_table_name_sql
+      BeetleETL::Naming.target_table_name_sql(@config.target_schema, @table_name)
     end
 
   end

--- a/lib/beetle_etl/steps/transform.rb
+++ b/lib/beetle_etl/steps/transform.rb
@@ -1,8 +1,8 @@
 module BeetleETL
   class Transform < Step
 
-    def initialize(table_name, dependencies, query)
-      super(table_name)
+    def initialize(config, table_name, dependencies, query)
+      super(config, table_name)
       @dependencies = dependencies
       @query = query
     end

--- a/lib/beetle_etl/testing.rb
+++ b/lib/beetle_etl/testing.rb
@@ -6,9 +6,14 @@ module BeetleETL
     TargetTableNotFoundError = Class.new(StandardError)
     NoTransformationFoundError = Class.new(StandardError)
 
+    def self.configure
+      @@config = Configuration.new
+      yield(@@config)
+    end
+
     def with_stage_tables_for(*table_names, &block)
       table_names.each do |table_name|
-        unless BeetleETL.database.table_exists?(table_name)
+        unless @@config.database.table_exists?(table_name)
           raise TargetTableNotFoundError.new <<-MSG
             Missing target table "#{table_name}".
             In order to create stage tables, BeetleETL requires the target tables to exist because they provide the column definitions.
@@ -16,12 +21,12 @@ module BeetleETL
         end
       end
 
-      test_wrapper = TestWrapper.new(table_names)
+      test_wrapper = TestWrapper.new(@@config, table_names)
       test_wrapper.run block
     end
 
     def run_transformation(table_name)
-      transformations = TransformationLoader.new.load
+      transformations = TransformationLoader.new(@@config).load
 
       unless transformations.map(&:table_name).include?(table_name)
         raise NoTransformationFoundError.new <<-MSG
@@ -30,13 +35,13 @@ module BeetleETL
       end
 
       transformation = transformations.find { |t| t.table_name == table_name }
-      transform = Transform.new(transformation.table_name, transformation.dependencies, transformation.query)
+      transform = Transform.new(@@config, transformation.table_name, transformation.dependencies, transformation.query)
       transform.run
     end
 
 
     def stage_table_name(table_name)
-      BeetleETL::Naming.stage_table_name(table_name)
+      BeetleETL::Naming.stage_table_name(@@config.external_source, table_name)
     end
 
   end

--- a/lib/beetle_etl/testing/test_wrapper.rb
+++ b/lib/beetle_etl/testing/test_wrapper.rb
@@ -1,6 +1,6 @@
 module BeetleETL
   module Testing
-    class TestWrapper < Struct.new(:table_names)
+    class TestWrapper < Struct.new(:config, :table_names)
 
       def run(block)
         begin
@@ -15,18 +15,18 @@ module BeetleETL
 
       def create_stages
         transformations.each do |t|
-          CreateStage.new(t.table_name, t.relations, t.column_names).run
+          CreateStage.new(config, t.table_name, t.relations, t.column_names).run
         end
       end
 
       def drop_stages
         transformations.each do |t|
-          DropStage.new(t.table_name).run
+          DropStage.new(config, t.table_name).run
         end
       end
 
       def transformations
-        @transformations ||= TransformationLoader.new.load.find_all do |transformation|
+        @transformations ||= TransformationLoader.new(config).load.find_all do |transformation|
           table_names.include? transformation.table_name
         end
       end

--- a/lib/beetle_etl/version.rb
+++ b/lib/beetle_etl/version.rb
@@ -1,3 +1,3 @@
 module BeetleETL
-  VERSION = "1.0.1"
+  VERSION = "2.0.0"
 end

--- a/spec/beetle_etl_spec.rb
+++ b/spec/beetle_etl_spec.rb
@@ -4,48 +4,16 @@ describe BeetleETL do
 
   describe '#import' do
     it 'runs the import with reporting' do
+      config = double(:config, disconnect_database: nil)
+      runner = double(:runner)
       report = double(:report)
       reporter = double(:reporter, log_summary: nil)
 
-      expect(BeetleETL::Import).to receive_message_chain(:new, :run).and_return report
-      expect(BeetleETL::Reporter).to receive(:new).with(report).and_return reporter
-      expect(BeetleETL.import).to eql(report)
-    end
-  end
+      expect(BeetleETL::Import).to receive(:new).with(config).and_return runner
+      expect(runner).to receive(:run).and_return report
+      expect(BeetleETL::Reporter).to receive(:new).with(config, report).and_return reporter
 
-  describe '#config' do
-    it 'returns a configuration object' do
-      expect(BeetleETL.config).to be_a(BeetleETL::Configuration)
-    end
-  end
-
-  describe '#configure' do
-    it 'allows the configuration to be changed' do
-      expect(BeetleETL.config.external_source).to be_nil
-
-      BeetleETL.configure { |config| config.external_source = 'foo' }
-
-      expect(BeetleETL.config.external_source).to eql('foo')
-    end
-  end
-
-  describe '#database' do
-    let(:database) { double(:database) }
-
-    it 'returns the Sequel Database object stored in the config' do
-      BeetleETL.configure { |config| config.database = database }
-
-      expect(BeetleETL.database).to eql(database)
-    end
-
-    it 'builds and caches a Sequel Database from config when no database is passed' do
-      database_config = double(:database_config)
-      BeetleETL.configure { |config| config.database_config = database_config }
-
-      expect(Sequel).to receive(:connect).with(database_config).once { database }
-
-      expect(BeetleETL.database).to eql(database)
-      expect(BeetleETL.database).to eql(database)
+      expect(BeetleETL.import(config)).to eql(report)
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+module BeetleETL
+  describe Configuration do
+
+    subject { Configuration.new }
+
+    describe "#database" do
+      let(:database) { double(:database) }
+
+      it "returns the object if present" do
+        subject.database = database
+
+        expect(subject.database).to eql(database)
+      end
+
+      it "builds a Sequel Database from config when no database is passed" do
+        database_config = double(:database_config)
+        subject.database_config = database_config
+
+        expect(Sequel).to receive(:connect).with(database_config).once { database }
+
+        expect(subject.database).to eql(database)
+        expect(subject.database).to eql(database)
+      end
+
+      it "raises an error if no database or database_config is passed" do
+        expect { subject.database }
+          .to raise_error(BeetleETL::InvalidConfigurationError)
+      end
+    end
+
+    describe "#disconnect_database" do
+      let(:database) { double(:database) }
+
+      it "disconnects from database if database_config was passed" do
+        database_config = double(:database_config)
+
+        expect(Sequel).to receive(:connect).with(database_config) { database }
+        expect(database).to receive(:disconnect)
+
+        subject.database_config = database_config
+        subject.disconnect_database
+      end
+
+      it "does not disconnect from database if database object was passed" do
+        expect(database).not_to receive(:disconnect)
+
+        subject.database = database
+        subject.disconnect_database
+      end
+    end
+
+    describe "#target_schema" do
+      it "returns nil if target_schema is 'public'" do
+        subject.target_schema = "public"
+        expect(subject.target_schema).to be_nil
+      end
+
+      it "returns target_schema if target_schema is not 'public'" do
+        subject.target_schema = "foo"
+        expect(subject.target_schema).to eql("foo")
+      end
+    end
+  end
+end

--- a/spec/dsl/dsl_spec.rb
+++ b/spec/dsl/dsl_spec.rb
@@ -3,18 +3,24 @@ require 'spec_helper'
 module BeetleETL
   describe DSL do
 
-    subject { DSL.new(:foo_table) }
+    let(:config) do
+      Configuration.new.tap do |c|
+        c.external_source = "bar"
+      end
+    end
+
+    subject { DSL.new(config, :foo_table) }
 
     describe '#stage_table' do
       it 'returns the current stage table name' do
         expect(subject.stage_table).to eql(
-          BeetleETL::Naming.stage_table_name_sql(:foo_table)
+          BeetleETL::Naming.stage_table_name_sql("bar", :foo_table)
         )
       end
 
       it 'returns the stage table name for the given table' do
         expect(subject.stage_table(:bar_table)).to eql(
-          BeetleETL::Naming.stage_table_name_sql(:bar_table)
+          BeetleETL::Naming.stage_table_name_sql("bar", :bar_table)
         )
       end
     end

--- a/spec/dsl/transformation_spec.rb
+++ b/spec/dsl/transformation_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 module BeetleETL
   describe Transformation do
 
+    let(:config) { Configuration.new }
+
     describe '#table_name' do
       it 'returns the given table name' do
-        transformation = Transformation.new(:table, Proc.new {})
+        transformation = Transformation.new(config, :table, Proc.new {})
         expect(transformation.table_name).to eql(:table)
       end
     end
@@ -15,7 +17,7 @@ module BeetleETL
         setup = Proc.new do
           columns :payload_1, 'payload_2'
         end
-        transformation = Transformation.new(:table, setup)
+        transformation = Transformation.new(config, :table, setup)
 
         expect(transformation.column_names).to match_array([
           :payload_1, :payload_2
@@ -23,7 +25,7 @@ module BeetleETL
       end
 
       it 'defaults to an empty array if no columns are defined' do
-        transformation = Transformation.new(:table, Proc.new {})
+        transformation = Transformation.new(config, :table, Proc.new {})
 
         expect(transformation.column_names).to match_array([])
       end
@@ -35,7 +37,7 @@ module BeetleETL
           references :foreign_table, on: :foreign_table_id
           references :another_foreign_table, on: :another_foreign_table_id
         end
-        transformation = Transformation.new(:table, setup)
+        transformation = Transformation.new(config, :table, setup)
 
         expect(transformation.relations).to eql({
           foreign_table_id: :foreign_table,
@@ -50,7 +52,7 @@ module BeetleETL
           references :foreign_table, on: :foreign_table_id
           references :another_foreign_table, on: :another_foreign_table_id
         end
-        transformation = Transformation.new(:table, setup)
+        transformation = Transformation.new(config, :table, setup)
 
         expect(transformation.dependencies).to eql(Set.new([:foreign_table, :another_foreign_table]))
       end
@@ -66,7 +68,7 @@ module BeetleETL
           query "SELECT '#{foo}' FROM some_table"
         end
 
-        transformation = Transformation.new(:table, setup, helpers)
+        transformation = Transformation.new(config, :table, setup, helpers)
 
         expect(transformation.query).to eql(
           "SELECT 'foo_string' FROM some_table"
@@ -78,7 +80,7 @@ module BeetleETL
           query "SOME QUERY"
           query "ANOTHER QUERY"
         end
-        transformation = Transformation.new(:table, setup)
+        transformation = Transformation.new(config, :table, setup)
 
         expect(transformation.query).to eql(
           "SOME QUERY;ANOTHER QUERY"

--- a/spec/feature/feature_spec.rb
+++ b/spec/feature/feature_spec.rb
@@ -23,11 +23,11 @@ describe BeetleETL do
     database_config_path = File.expand_path('../support/database.yml', File.dirname(__FILE__))
     database_config = YAML.load(File.read(database_config_path))
 
-    BeetleETL.configure do |config|
-      config.transformation_file = File.expand_path('../example_transform.rb', __FILE__)
-      config.database_config = database_config
-      config.external_source = 'source_name'
-      config.logger = Logger.new(Tempfile.new("log"))
+    @config = BeetleETL::Configuration.new.tap do |c|
+      c.transformation_file = File.expand_path('../example_transform.rb', __FILE__)
+      c.database_config = database_config
+      c.external_source = 'source_name'
+      c.logger = Logger.new(Tempfile.new("log"))
     end
   end
 
@@ -54,7 +54,7 @@ describe BeetleETL do
     )
 
     Timecop.freeze(time1) do
-      BeetleETL.import
+      BeetleETL.import(@config)
     end
 
     expect(:organisations).to have_values(
@@ -86,7 +86,7 @@ describe BeetleETL do
     )
 
     Timecop.freeze(time2) do
-      BeetleETL.import
+      BeetleETL.import(@config)
     end
 
     expect(:organisations).to have_values(
@@ -118,7 +118,7 @@ describe BeetleETL do
     )
 
     Timecop.freeze(time3) do
-      BeetleETL.import
+      BeetleETL.import(@config)
     end
 
     expect(:organisations).to have_values(

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -38,7 +38,10 @@ module BeetleETL
     end
 
     it "loggs a summary of all step times by table name" do
-      expect(BeetleETL.logger).to receive(:info).with <<-LOG.unindent
+      config = Configuration.new.tap do |c|
+        c.logger = double(:logger)
+      end
+      expect(config.logger).to receive(:info).with <<-LOG.unindent
 
 
         organisations
@@ -58,7 +61,7 @@ module BeetleETL
                         01:31:39
       LOG
 
-      Reporter.new(report).log_summary
+      Reporter.new(config, report).log_summary
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
+require "byebug"
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
-require_relative '../lib/beetle_etl.rb'
-require_relative 'support/database_helpers.rb'
-require_relative 'support/file_helpers.rb'
+require_relative "../lib/beetle_etl.rb"
+require_relative "support/database_helpers.rb"
+require_relative "support/file_helpers.rb"
 
 RSpec.configure do |config|
 
@@ -13,8 +14,6 @@ RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/rspec-core/]
 
   config.around(:each) do |example|
-    BeetleETL.reset
-
     if example.metadata[:feature]
       example.run
     else

--- a/spec/steps/assign_ids_spec.rb
+++ b/spec/steps/assign_ids_spec.rb
@@ -6,15 +6,15 @@ module BeetleETL
     let(:external_source) { 'my_source' }
     let(:another_source) { 'another_source' }
 
-    subject { AssignIds.new(:example_table) }
-
-    before do
-      BeetleETL.configure do |config|
-        config.stage_schema = 'stage'
-        config.external_source = external_source
-        config.database = test_database
+    let(:config) do
+      Configuration.new.tap do |c|
+        c.stage_schema = 'stage'
+        c.external_source = external_source
+        c.database = test_database
       end
     end
+
+    subject { AssignIds.new(config, :example_table) }
 
     describe '#dependencies' do
       it 'depends on TableDiff of the same table' do

--- a/spec/steps/load_spec.rb
+++ b/spec/steps/load_spec.rb
@@ -11,14 +11,16 @@ module BeetleETL
     let(:now) { Time.now.beginning_of_day }
     let(:yesterday) { 1.day.ago.beginning_of_day }
 
-    subject { Load.new(:example_table, []) }
+    let(:config) do
+      Configuration.new.tap do |c|
+        c.external_source = external_source
+        c.database = test_database
+      end
+    end
+
+    subject { Load.new(config, :example_table, []) }
 
     before do
-      BeetleETL.configure do |config|
-        config.external_source = external_source
-        config.database = test_database
-      end
-
       allow(subject).to receive(:now) { now }
 
       test_database.create_schema(:stage)
@@ -54,7 +56,7 @@ module BeetleETL
           dependee_b_id: :dependee_b,
         }
 
-        expect(Load.new(:depender, relations).dependencies).to eql(
+        expect(Load.new(config, :depender, relations).dependencies).to eql(
           [
             'dependee_a: Load',
             'dependee_b: Load',

--- a/spec/steps/map_relations_spec.rb
+++ b/spec/steps/map_relations_spec.rb
@@ -3,8 +3,19 @@ require 'spec_helper'
 module BeetleETL
   describe MapRelations do
 
-    let(:dependee_a) { BeetleETL::Naming.stage_table_name(:dependee_a).to_sym }
-    let(:dependee_b) { BeetleETL::Naming.stage_table_name(:dependee_b).to_sym }
+    let(:config) do
+      Configuration.new.tap do |c|
+        c.external_source = 'my_source'
+        c.database = test_database
+      end
+    end
+
+    let(:dependee_a) do
+      BeetleETL::Naming.stage_table_name('my_source', :dependee_a).to_sym
+    end
+    let(:dependee_b) do
+      BeetleETL::Naming.stage_table_name('my_source', :dependee_b).to_sym
+    end
 
     let(:relations) do
       {
@@ -14,15 +25,10 @@ module BeetleETL
     end
 
     subject do
-      MapRelations.new(:depender, relations)
+      MapRelations.new(config, :depender, relations)
     end
 
     before do
-      BeetleETL.configure do |config|
-        config.external_source = 'my_source'
-        config.database = test_database
-      end
-
       test_database.create_table(dependee_a) do
         Integer :id
         String :external_id, size: 255

--- a/spec/steps/step_spec.rb
+++ b/spec/steps/step_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 module BeetleETL
   describe Step do
 
-    subject { Step.new(:example_table) }
+    let(:config) { Configuration.new }
+
+    subject { Step.new(config, :example_table) }
     FooStep = Class.new(Step)
 
     describe '.step_name' do
@@ -18,11 +20,11 @@ module BeetleETL
 
     describe '#name' do
       it 'returns the steps name' do
-        expect(Step.new(:example_table).name).to eql('example_table: Step')
+        expect(Step.new(config, :example_table).name).to eql('example_table: Step')
       end
 
       it 'returns the step name of inheriting steps' do
-        expect(FooStep.new(:foo_table).name).to eql('foo_table: FooStep')
+        expect(FooStep.new(config, :foo_table).name).to eql('foo_table: FooStep')
       end
     end
 

--- a/spec/steps/table_diff_spec.rb
+++ b/spec/steps/table_diff_spec.rb
@@ -7,15 +7,16 @@ module BeetleETL
   describe TableDiff do
 
     let(:external_source) { 'my_source' }
+    let(:config) do
+      Configuration.new.tap do |c|
+        c.external_source = external_source
+        c.database = test_database
+      end
+    end
 
-    subject { TableDiff.new(:example_table) }
+    subject { TableDiff.new(config, :example_table) }
 
     before do
-      BeetleETL.configure do |config|
-        config.external_source = external_source
-        config.database = test_database
-      end
-
       test_database.create_table(subject.stage_table_name.to_sym) do
         String :external_id, size: 255
         String :transition, size: 20

--- a/spec/steps/transform_spec.rb
+++ b/spec/steps/transform_spec.rb
@@ -3,10 +3,17 @@ require 'spec_helper'
 module BeetleETL
   describe Transform do
 
+    let(:database) { double(:database) }
+    let(:config) do
+      Configuration.new.tap do |c|
+        c.database = database
+      end
+    end
     let(:query) { double(:query) }
+
     subject do
       deps = [:some_table, :some_other_table].to_set
-      Transform.new(:example_table, deps, query)
+      Transform.new(config, :example_table, deps, query)
     end
 
     describe '#dependencies' do
@@ -22,9 +29,6 @@ module BeetleETL
 
     describe '#run' do
       it 'runs a query in the database' do
-        database = double(:database)
-        BeetleETL.configure { |config| config.database = database }
-
         expect(database).to receive(:run).with(query)
 
         subject.run

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -22,7 +22,7 @@ describe "BeetleETL:Testing" do
       end
     FILE
 
-    BeetleETL.configure do |config|
+    BeetleETL::Testing.configure do |config|
       config.database = test_database
       config.transformation_file = data_file.path
     end


### PR DESCRIPTION
This removes the ```BeetleETL.configure``` in favour of explicitly passing a configuration object into the ```BeetleETL.import``` call. This enables running multiple instances of BeetleETL for different configurations and removes global state. yay.